### PR TITLE
AXI-in-simulation, DMA window fixes

### DIFF
--- a/bluespec/CHERI_BGAS_System.bsv
+++ b/bluespec/CHERI_BGAS_System.bsv
@@ -50,17 +50,24 @@ import VirtualDevice :: *;
 ////////////////////////////////////////////////////////////////////////////////
 
 // A straightforward axi lite subordinate to provide a banking mechanism for
-// the h2f window into the core's memory map
-module mkH2FAddrCtrl #(Bit #(t_h2f_addr) dfltAddrBits)
+// the h2f window into the core's memory map.
+//
+// Exposes a readable/writable Wd_Addr at relative address 0x0
+// such that the LSB is bit 0 of address 0
+// and the MSB is bit 7 of address 0x3 or 0x7, if Wd_Addr is 32 or 64 respectively.
+// WSTRB is *ignored*.
+// This mapping is repeated over the remaining address space, so 0x8 maps to the same thing as 0x0.
+module mkH2FAddrCtrl #(Bit #(Wd_Addr) dfltAddrBits)
   (Tuple2 #( AXI4Lite_Slave #( t_h2f_lw_addr, t_h2f_lw_data
                              , t_h2f_lw_awuser, t_h2f_lw_wuser, t_h2f_lw_buser
                              , t_h2f_lw_aruser, t_h2f_lw_ruser)
-           , ReadOnly #(Bit #(t_h2f_addr)) ))
+           , ReadOnly #(Bit #(Wd_Addr)) ))
   provisos (
-    NumAlias #( t_dats_per_addr, TDiv#(t_h2f_addr,t_h2f_lw_data))
+    NumAlias #( t_dats_per_addr, TDiv#(Wd_Addr, t_h2f_lw_data))
   , NumAlias #( t_dat_select, TLog#(t_dats_per_addr))
+  , NumAlias #( t_sub_lw_word_addr_bits, TLog#(TDiv#(t_h2f_lw_data, 8)))
   , Add#(a__, t_dat_select, t_h2f_lw_addr)
-  , Mul#(TDiv#(t_h2f_addr, t_h2f_lw_data), t_h2f_lw_data, t_h2f_addr) // Evenly divisible
+  , Mul#(TDiv#(Wd_Addr, t_h2f_lw_data), t_h2f_lw_data, Wd_Addr) // Evenly divisible
   );
 
   // internal state and signals
@@ -70,7 +77,9 @@ module mkH2FAddrCtrl #(Bit #(t_h2f_addr) dfltAddrBits)
   // read requests handling (always answer with upper bits)
   rule read_req;
     let ar <- get (axiShim.master.ar);
-    Bit#(t_dat_select) i = truncate(ar.araddr);
+    // e.g. if lw_data is 32-bits = 4 bytes then shift down by log2(4) = 2
+    // so address 0x4 becomes 0b100 >> 2 = 0b1 = word 1 of addrBits
+    Bit#(t_dat_select) i = truncate(ar.araddr >> valueOf(t_sub_lw_word_addr_bits));
     axiShim.master.r.put (AXI4Lite_RFlit { rdata: addrBits[i]
                                          , rresp: OKAY
                                          , ruser: ? });
@@ -79,7 +88,8 @@ module mkH2FAddrCtrl #(Bit #(t_h2f_addr) dfltAddrBits)
   // write requests handling (update the appropriate word of addrBits)
   rule write_req;
     let aw <- get (axiShim.master.aw);
-    Bit#(t_dat_select) i = truncate(aw.awaddr);
+    // see read_req for explanation of shift
+    Bit#(t_dat_select) i = truncate(aw.awaddr >> valueOf(t_sub_lw_word_addr_bits));
     let w <- get (axiShim.master.w);
     addrBits[i] <= w.wdata;
     axiShim.master.b.put (AXI4Lite_BFlit { bresp: OKAY
@@ -596,6 +606,14 @@ module mkCHERI_BGAS_System ( CHERI_BGAS_System_Ifc #(
     subShim <- replicateM (mkAXI4ShimFF (reset_by newRst.new_rst));
 
   // H2F interface wrapping (extra address bits & data size shim)
+  // h2fAddrCtrlRO is Bits#(Wd_Addr) in size, i.e. 32-bit unless FABRIC64 is defined in which case 64-bit.
+  // FABRIC64 is usually defined.
+  // toWider_AXI4_Slave produces a new AXI slave with double the data width of the argument.
+  // prepend_AXI4_Slave_addr produces a new AXI slave from an argument,
+  // where transactions to the new AXI slave (of *fewer* address bits) are passed to the argument with 
+  // *extra* address bits prepended.
+  // This address of {32'b0, h2f_addr'32} is then OR-d with `h2fAddrCtrlRO` by `or_AXI4_Slave_addr`,
+  // before arriving at the shim.
   t_h2f_sub h2fSub <- toWider_AXI4_Slave (
                         zero_AXI4_Slave_user (
                           prepend_AXI4_Slave_addr ( 32'b0


### PR DESCRIPTION
- Bump cheri-bgas-fuse-devfs to include correct WSTRB bits on 128-bit accesses, and to only expose a single H2F fmem device encompassing the entire window
- Add comments to explain the operation and memory map of the mkH2FAddrCtrl, which controls the DMA window
- Restrict the mkH2FAddrCtrl to return an address of Wd_Addr size, reflecting the intent and improving readability
- Correct the mkH2FAddrCtrl memory map - previously the first word of the DMA window address was presented at 0x0, then the second word at 0x1 regardless of the word width. Now if e.g. the H2F_lw words are 32-bit, the first word is mapped to 0x0 and the second to 0x4. This enables tinyemu-virtio to use 64-bit offsets, although I haven't tested that functionality yet.